### PR TITLE
feat: 支持动态首页视频解析，并修复首页携带查询参数时脚本不生效的问题

### DIFF
--- a/BiliAnalysis-dev.user.js
+++ b/BiliAnalysis-dev.user.js
@@ -1090,6 +1090,7 @@
      */
     function processCover(element, type) {
         if (isFocusCardElement(element)) return;
+        if (type === 'video' && element.matches?.('a.bili-dyn-card-video')) return;
         const link = element.href || element.querySelector('a')?.href || element.closest('a[href]')?.href;
         const imgEl = element.querySelector('img');
         if (!link || !imgEl) return; // 确认具有有效链接和图片

--- a/BiliAnalysis-dev.user.js
+++ b/BiliAnalysis-dev.user.js
@@ -6,10 +6,12 @@
 // @icon         https://i.ouo.chat/favicon.ico
 // @author       https://github.com/mmyo456/BiliAnalysis
 // @match        https://www.bilibili.com/
+// @include      https://www.bilibili.com/?*
 // @match        https://www.bilibili.com/video*
 // @match        https://www.bilibili.com/*bvid*
 // @match        https://www.bilibili.com/v/popular*
 // @match        https://www.bilibili.com/history*
+// @match        https://t.bilibili.com/*
 // @match        https://live.bilibili.com/*
 // @match        https://search.bilibili.com/*
 // @match        https://space.bilibili.com/*
@@ -1088,7 +1090,7 @@
      */
     function processCover(element, type) {
         if (isFocusCardElement(element)) return;
-        const link = element.href || element.querySelector('a')?.href;
+        const link = element.href || element.querySelector('a')?.href || element.closest('a[href]')?.href;
         const imgEl = element.querySelector('img');
         if (!link || !imgEl) return; // 确认具有有效链接和图片
         if (isSmallAvatarImage(imgEl)) return;
@@ -1148,7 +1150,8 @@
         const videoSelectors = [
             '.video-card .pic-box', '.bili-video-card .bili-video-card__image',
             '.small-item .cover', '.card-pic', 'a[href*="/video/BV"]',
-            '.cover-container', '.list-item .cover'
+            '.cover-container', '.list-item .cover',
+            '.bili-dyn-card-video__cover'
         ];
 
         const liveSelectors = [

--- a/BiliAnalysis-main.user.js
+++ b/BiliAnalysis-main.user.js
@@ -1090,6 +1090,7 @@
      */
     function processCover(element, type) {
         if (isFocusCardElement(element)) return;
+        if (type === 'video' && element.matches?.('a.bili-dyn-card-video')) return;
         const link = element.href || element.querySelector('a')?.href || element.closest('a[href]')?.href;
         const imgEl = element.querySelector('img');
         if (!link || !imgEl) return; // 确认具有有效链接和图片

--- a/BiliAnalysis-main.user.js
+++ b/BiliAnalysis-main.user.js
@@ -6,10 +6,12 @@
 // @icon         https://i.ouo.chat/favicon.ico
 // @author       https://github.com/mmyo456/BiliAnalysis
 // @match        https://www.bilibili.com/
+// @include      https://www.bilibili.com/?*
 // @match        https://www.bilibili.com/video*
 // @match        https://www.bilibili.com/*bvid*
 // @match        https://www.bilibili.com/v/popular*
 // @match        https://www.bilibili.com/history*
+// @match        https://t.bilibili.com/*
 // @match        https://live.bilibili.com/*
 // @match        https://search.bilibili.com/*
 // @match        https://space.bilibili.com/*
@@ -1088,7 +1090,7 @@
      */
     function processCover(element, type) {
         if (isFocusCardElement(element)) return;
-        const link = element.href || element.querySelector('a')?.href;
+        const link = element.href || element.querySelector('a')?.href || element.closest('a[href]')?.href;
         const imgEl = element.querySelector('img');
         if (!link || !imgEl) return; // 确认具有有效链接和图片
         if (isSmallAvatarImage(imgEl)) return;
@@ -1148,7 +1150,8 @@
         const videoSelectors = [
             '.video-card .pic-box', '.bili-video-card .bili-video-card__image',
             '.small-item .cover', '.card-pic', 'a[href*="/video/BV"]',
-            '.cover-container', '.list-item .cover'
+            '.cover-container', '.list-item .cover',
+            '.bili-dyn-card-video__cover'
         ];
 
         const liveSelectors = [


### PR DESCRIPTION
  ## 变更说明

  本次 PR 主要解决两个问题：

  1. 新增 `https://t.bilibili.com/*` 动态首页的视频封面解析支持
  2. 修复首页地址携带查询参数时脚本无法正常生效的问题，例如：
     - `https://www.bilibili.com/?spm_id_from=333.1365.0.0`

  ## 具体修改

  - 新增 userscript 匹配规则：
    - `https://t.bilibili.com/*`
  - 为首页根路径补充显式匹配：
    - `https://www.bilibili.com/?*`
  - 新增动态首页视频封面选择器：
      - 动态页封面容器 .bili-dyn-card-video__cover 处理
      - 动态页外层整卡链接 a.bili-dyn-card-video 直接跳过
  - 优化封面链接提取逻辑：
    - 支持从当前节点、子节点 `a`、以及最近外层 `a[href]` 获取视频链接
  - 修复动态首页重复注入按钮的问题：
    - 仅在视频封面区域挂载解析按钮，避免在简介卡片区域重复显示

  ## 修复效果

  ### 动态首页

  支持在动态首页的视频封面上显示“本地解析”按钮。

  ### 首页带查询参数

  以下地址现在也可以正常解析视频封面：

  - `https://www.bilibili.com/?spm_id_from=333.1365.0.0`

  ## 测试情况

  已手动验证以下页面：

  - `https://www.bilibili.com/`
  - `https://www.bilibili.com/?spm_id_from=333.1365.0.0`
  - `https://t.bilibili.com/`

  验证结果：

  - 首页视频封面解析正常
  - 首页带查询参数时解析正常
  - 动态首页视频封面可正常显示解析按钮
  - 动态首页不再出现重复按钮

  ## 截图

  ### 动态首页新增解析按钮
 
<img width="1078" height="744" alt="image" src="https://github.com/user-attachments/assets/a4e850df-b899-4376-be63-0af2c2d88d01" />
<img width="1114" height="508" alt="image" src="https://github.com/user-attachments/assets/e14aacc4-3c72-4aad-882c-06fa8e806314" />


  ### 首页携带查询参数时可正常解析
  - 页面地址：`https://www.bilibili.com/?spm_id_from=333.1365.0.0`
  
<img width="3048" height="1136" alt="image" src="https://github.com/user-attachments/assets/03d2cc0c-fc94-4e42-9836-295e9f028b24" />


